### PR TITLE
adding string comparism to sort by new name scheme

### DIFF
--- a/src/app/dorfgeschehen/dorfzeitung/page.tsx
+++ b/src/app/dorfgeschehen/dorfzeitung/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
 
   useEffect(() => {
     fetchNewspaper().then((data) => {
-      setFileNames(data.reverse());
+      setFileNames(data.sort((a: string, b: string) => a.localeCompare(b, 'de', { numeric: true })).reverse());
       if (data.length > 0 && selectedPDF === '') {
         setSelectedPDF(data[0]);
       }


### PR DESCRIPTION
We need to name the pdf files according to this scheme:
"year-month" ex. "2023-07" for July 2023. 
The sorting will be reversed afterwards to have the most recent paper on top. The uploading should get some kind of framework later so that the user can set a month and year for the pdf file. These can be used for sorting. At the current state this is way too much work for the effort.